### PR TITLE
Composer dev packages are installed by default

### DIFF
--- a/Mage/Task/BuiltIn/Composer/InstallTask.php
+++ b/Mage/Task/BuiltIn/Composer/InstallTask.php
@@ -24,6 +24,6 @@ class InstallTask extends ComposerAbstractTask
     public function run()
     {
         $dev = $this->getParameter('dev', true);
-        return $this->runCommand($this->getComposerCmd() . ' install' . ($dev ? ' --dev' : ' --no-dev'));
+        return $this->runCommand($this->getComposerCmd() . ' install' . ($dev ? '' : ' --no-dev'));
     }
 }

--- a/Mage/Task/BuiltIn/Composer/UpdateTask.php
+++ b/Mage/Task/BuiltIn/Composer/UpdateTask.php
@@ -24,6 +24,6 @@ class UpdateTask extends ComposerAbstractTask
     public function run()
     {
         $dev = $this->getParameter('dev', true);
-        return $this->runCommand($this->getComposerCmd() . ' update' . ($dev ? ' --dev' : ' --no-dev'));
+        return $this->runCommand($this->getComposerCmd() . ' update' . ($dev ? '' : ' --no-dev'));
     }
 }


### PR DESCRIPTION
Opening new PR to `develop` instead of `master` as requested https://github.com/magephp/magallanes/pull/5

`$ composer install --dev` and `$ composer update --dev` commands return this message:
`You are using the deprecated option "dev". Dev packages are installed by default now.`